### PR TITLE
fix: Add `subnets_by_region` output to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ No resources.
 |------|-------------|
 | <a name="output_self_link"></a> [self\_link](#output\_self\_link) | The fully-qualified self-link URI of the created VPC network. |
 | <a name="output_subnets"></a> [subnets](#output\_subnets) | A map of subnet name to region, self\_link, and CIDRs. |
+| <a name="output_subnets_by_region"></a> [subnets\_by\_region](#output\_subnets\_by\_region) | A map of subnet region to name, self\_link, and CIDRs. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 <!-- markdownlint-enable MD033 MD034 -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,3 +16,16 @@ output "subnets" {
   A map of subnet name to region, self_link, and CIDRs.
   EOD
 }
+
+
+output "subnets_by_region" {
+  value = { for k, v in module.network.subnets : v.region => {
+    name            = v.name
+    self_link       = v.self_link
+    primary_cidr    = v.ip_cidr_range
+    secondary_cidrs = v.secondary_ip_range
+  } }
+  description = <<-EOD
+  A map of subnet region to name, self_link, and CIDRs.
+  EOD
+}

--- a/test/fixtures/root/outputs.tf
+++ b/test/fixtures/root/outputs.tf
@@ -9,6 +9,10 @@ output "subnets_json" {
   value = jsonencode(module.test.subnets)
 }
 
+output "subnets_by_region_json" {
+  value = jsonencode(module.test.subnets_by_region)
+}
+
 # Output some of the inputs as JSON objects to make it easier to process in kitchen
 output "cidrs_json" {
   value = jsonencode(var.cidrs)

--- a/test/integration/multi-region-private-network/controls/outputs.rb
+++ b/test/integration/multi-region-private-network/controls/outputs.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# rubocop:disable Layout/LineLength
+NETWORK_SELF_LINK_PATTERN = %r{projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/global/networks/[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$}
+SUBNET_NAME_PATTERN = /[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+SUBNET_SELF_LINK_PATTERN = %r{projects/[a-z][a-z0-9-]{4,28}[a-z0-9]/regions/[a-z]{2,}-[a-z]{2,}[0-9]/subnetworks/[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$}
+# rubocop:enable Layout/LineLength
+
+control 'outputs' do
+  title 'Ensure module outputs match expectations'
+  impact 1.0
+  self_link = input('output_self_link')
+  subnets = JSON.parse(input('output_subnets_json'), { symbolize_names: true })
+  subnets_by_region = JSON.parse(input('output_subnets_by_region_json'), { symbolize_names: true })
+
+  describe self_link do
+    it { should_not be_nil }
+    it { should match(NETWORK_SELF_LINK_PATTERN) }
+  end
+
+  subnets.each do |k, v|
+    describe k do
+      it { should match(SUBNET_NAME_PATTERN) }
+      it { should cmp subnets_by_region[v[:region].to_sym][:name] }
+    end
+    describe v[:self_link] do
+      it { should match(SUBNET_SELF_LINK_PATTERN) }
+    end
+    # subnets and subnets_by_region values should match execept that the former
+    # has a 'region' value, and the latter has a 'name' value.
+    compare_subnets_values = v.reject { |prop, _| prop == :region }
+    compare_subnets_by_region_values = subnets_by_region[v[:region].to_sym].reject { |prop, _| prop == :name }
+    describe compare_subnets_values do
+      it { should cmp compare_subnets_by_region_values }
+    end
+  end
+end

--- a/test/integration/multi-region-private-network/inspec.yml
+++ b/test/integration/multi-region-private-network/inspec.yml
@@ -17,6 +17,9 @@ inputs:
   - name: output_subnets_json
     type: string
     required: true
+  - name: output_subnets_by_region_json
+    type: string
+    required: true
   - name: output_options_json
     type: string
     required: true


### PR DESCRIPTION
This adds an additional output that maps the Compute Engine region to a set of subnetwork properties.

Also includes a new inspec control to verify that `subnets` and `subnets_by_region` match on common properties.

Closes #11.