### PR TITLE
fix: Restrict Google provider to <7

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ egress traffic, and IPv6 ULA addressing enabled.
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     name       = "internal-us"
     regions    = ["us-east1", "us-west1"]
@@ -84,7 +84,7 @@ module "vpc" {
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     name       = "internal-us"
     regions    = ["us-east1", "us-west1"]
@@ -121,7 +121,7 @@ module "vpc" {
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     regions    = ["us-east1", "us-west1"]
     cidrs      = {
@@ -170,7 +170,7 @@ module "vpc" {
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     regions    = ["us-east1", "us-west1"]
     nat = {
@@ -202,7 +202,7 @@ module "vpc" {
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     regions    = ["us-east1", "us-west1"]
     options    = {
@@ -236,7 +236,7 @@ module "vpc" {
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     regions    = ["us-east1", "us-west1"]
     cidrs      = {
@@ -279,7 +279,7 @@ module "vpc" {
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     regions    = ["us-east1", "us-west1"]
     cidrs      = {
@@ -323,7 +323,7 @@ module "vpc" {
 ```hcl
 module "vpc" {
     source     = "memes/multi-region-private-network/google"
-    version    = "4.0.0"
+    version    = "4.0.1"
     project_id = "my-project-id"
     regions    = ["us-east1", "us-west1"]
     psc        = {

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ module "vpc" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.25 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.25, <7 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.25"
+      version = ">= 6.25, <7"
     }
   }
 }


### PR DESCRIPTION
Add a constraint to module so that Google provider is restricted to less than v7.

Closes #95.